### PR TITLE
feat: Add ConvertKit newsletter form to blog posts

### DIFF
--- a/_includes/convertkit.html
+++ b/_includes/convertkit.html
@@ -1,0 +1,1 @@
+<script async data-uid="82ab3d36b8" src="https://relentless-trailblazer-8093.kit.com/82ab3d36b8/index.js"></script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -25,6 +25,8 @@ layout: default
     {{ content }}
   </div>
 
+  {%- include convertkit.html -%}
+
   {%- if site.talkyard_server_url -%}
     <div class="post-comments">
       {%- include talkyard-comments.html -%}


### PR DESCRIPTION
This commit integrates a ConvertKit newsletter subscription form into the website.

The form is added to the bottom of each blog post, after the content and before the comments section. This is achieved by creating a new include file for the ConvertKit embed code and adding it to the post layout.