### PR TITLE
Replace ConvertKit with Buttondown for email subscriptions

### DIFF
--- a/_includes/buttondown.html
+++ b/_includes/buttondown.html
@@ -1,0 +1,12 @@
+<form
+  action="https://buttondown.com/api/emails/embed-subscribe/bankole"
+  method="post"
+  target="popupwindow"
+  onsubmit="window.open('https://buttondown.com/bankole', 'popupwindow')"
+  class="embeddable-buttondown-form"
+>
+  <label for="bd-email">Enter your email</label>
+  <input type="email" name="email" id="bd-email" />
+
+  <input type="submit" value="Subscribe" />
+</form>

--- a/_includes/convertkit.html
+++ b/_includes/convertkit.html
@@ -1,1 +1,0 @@
-<script async data-uid="82ab3d36b8" src="https://relentless-trailblazer-8093.kit.com/82ab3d36b8/index.js"></script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -25,7 +25,7 @@ layout: default
     {{ content }}
   </div>
 
-  {%- include convertkit.html -%}
+  {%- include buttondown.html -%}
 
   {%- if site.talkyard_server_url -%}
     <div class="post-comments">


### PR DESCRIPTION
This commit replaces the ConvertKit email subscription form with a new form from Buttondown.

The changes include:
- A new `_includes/buttondown.html` file with the Buttondown embed code.
- An update to `_layouts/post.html` to use the new Buttondown include.
- Removal of the old `_includes/convertkit.html` file.
- The "Powered by Buttondown" link has been removed from the form as you requested.